### PR TITLE
Bump kernel32-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ name = "msdos_time"
 [dependencies]
 time = "0.1"
 winapi = "0.2"
-kernel32-sys = "0.1"
+kernel32-sys = "0.2"


### PR DESCRIPTION
Please bump version of msdos_time once this PR is tested (especially on Windows) and merged
