### PR TITLE
bump winapi to version 0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ name = "msdos_time"
 time = "0.1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+winapi = { version = "0.3", features = ["winbase", "timezoneapi"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //! It is currently mostly used in zip files.
 
 extern crate time;
-#[cfg(windows)] extern crate kernel32;
 #[cfg(windows)] extern crate winapi;
 
 use std::io;
@@ -93,8 +92,10 @@ mod sys {
 mod sys {
     use super::MsDosDateTime;
     use time::{self, Tm};
-    use winapi::*;
-    use kernel32::*;
+    use winapi::shared::minwindef::{WORD, FILETIME};
+    use winapi::um::minwinbase::SYSTEMTIME;
+    use winapi::um::timezoneapi::{FileTimeToSystemTime, SystemTimeToFileTime};
+    use winapi::um::winbase::{DosDateTimeToFileTime, FileTimeToDosDateTime};
     use std::io;
 
     pub fn msdos_to_tm(ms: MsDosDateTime) -> Result<Tm, io::Error> {


### PR DESCRIPTION
Currently, this crate requires two versions of `winapi` (`time` requires `0.3`). let's fix this

@mvdnes if it looks good, can you publish a new version to crates.io?